### PR TITLE
adds deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "virtual-dom-starter",
+  "homepage": "https://virtual-dom-starter.surge.sh",
   "scripts": {
     "build": "browserify main.js | uglifyjs -cm > public/bundle.js",
+    "deploy": "npm run build && surge public $npm_package_homepage",
     "start": "ecstatic -p 8000 public",
     "watch": "watchify main.js -o public/bundle.js -dv"
   },
@@ -11,6 +13,7 @@
     "main-loop": "^3.1.0",
     "uglify": "~0.1.5",
     "virtual-dom": "^2.0.1",
-    "watchify": "^3.2.3"
+    "watchify": "^3.2.3",
+    "surge": "^0.14.3"
   }
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -18,6 +18,7 @@ $ npm start
 
 * `npm run build` - build js for production
 * `npm run watch` - automatically build js on file changes for development
+* `npm run deploy` - build for production and deploy to project homepage
 * `npm start` - start a development server
 
 # starter code


### PR DESCRIPTION
Deploying to surge seems fitting in this situation as it doesn't require any setup and project is implicitly created on first deploy. @substack you may want to be the first to run `npm run deploy` in order to claim the domain. Let me know what you think.