### PR TITLE
Fix uglifyjs devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "browserify": "^10.2.6",
     "ecstatic": "~0.8.0",
     "main-loop": "^3.1.0",
-    "uglify": "~0.1.5",
+    "uglifyjs": "~2.4.10",
     "virtual-dom": "^2.0.1",
     "watchify": "^3.2.3"
   }


### PR DESCRIPTION
Changes package.json to pull in `uglifyjs`, the shell script used in `npm run build` (not uglify). Lots of folks `npm i -g uglifyjs`, masking the mismatch.

```shellsession
$ npm i
...
$ npm run build

> virtual-dom-starter@ build /home/kyle/tmp/virtual-dom-starter> browserify main.js | uglifyjs -cm > public/bundle.js

sh: 1: uglifyjs: not found
...
```

Thanks so much for pushing this starter. I've been toying with virtual-dom, but hadn't seen main-loop.